### PR TITLE
Removing real repository from copy-paste example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Or to push docs changes automatically to a `gh-pages` branch:
 ```yaml
     - name: Commit documentation changes
       run: |
-        git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
+        git clone https://github.com/your_git/repository.git --branch gh-pages --single-branch gh-pages
         cp -r docs/_build/html/* gh-pages/
         cd gh-pages
         git config --local user.email "action@github.com"


### PR DESCRIPTION
Hello,

I'm proposing a small change to the sphinx-action README. 

**Problem:** The deploy docs example in the README is a valid action that will run successfully without modification. This action will clone code from `https://github.com/ammaraskar/sphinx-action-test.git` by default. This behavior is problematic because it allows users to copy-paste the action and successfully run it without the necessary modifications. If no changes are made  the action clones @ammaraskar 's sphinx-action-test github repository in to the `gh-pages` branch of the local repository trying to use the action leading to an unfortunate side-effect.

*  User [ammaraskar](https://github.com/ammaraskar) is added as a contributor to the project. This action cannot be undone.

It is not in users' interest to accidentally add a contributor to the project who does not belong on the project. It is not in ammaraskar's interest to be added to projects that they did not willingly contribute to. 

**Solution:** Don't let users shoot themselves in the foot. Replace the git clone URL with a fake repository. If run without proper modification, the action will simply fail. This approach is safer and more desirable than erroneously adding a contributor who does not belong on the project
